### PR TITLE
Add overloads to Threshold.TryParse and Frequency.TryParse* methods

### DIFF
--- a/src/Perfolizer/Perfolizer.Tests/Horology/FrequencyTests.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Horology/FrequencyTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Perfolizer.Horology;
@@ -66,6 +67,22 @@ namespace Perfolizer.Tests.Horology
             Assert.True(Frequency.TryParseMHz("9.87654321", out var c));
             Assert.Equal(9876543.21, c.Hertz, 4);
             Assert.True(Frequency.TryParseGHz("0.000000003", out var d));
+            Assert.Equal(3, d.Hertz, 4);
+        }
+
+        [Fact]
+        public void ParseTestDifferentFormat()
+        {
+            var numberStyle = NumberStyles.Any;
+            var frenchFormat = new CultureInfo("fr-FR");
+
+            Assert.True(Frequency.TryParseHz("2", numberStyle, frenchFormat, out var a));
+            Assert.Equal(2, a.Hertz, 4);
+            Assert.True(Frequency.TryParseKHz("3,456", numberStyle, frenchFormat, out var b));
+            Assert.Equal(3456, b.Hertz, 4);
+            Assert.True(Frequency.TryParseMHz("9,87654321", numberStyle, frenchFormat, out var c));
+            Assert.Equal(9876543.21, c.Hertz, 4);
+            Assert.True(Frequency.TryParseGHz("0,000000003", numberStyle, frenchFormat, out var d));
             Assert.Equal(3, d.Hertz, 4);
         }
 

--- a/src/Perfolizer/Perfolizer.Tests/Mathematics/Thresholds/ThresholdTests.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Mathematics/Thresholds/ThresholdTests.cs
@@ -1,0 +1,48 @@
+﻿using Perfolizer.Mathematics.Thresholds;
+using System.Globalization;
+using Xunit;
+
+namespace Perfolizer.Tests.Mathematics.Thresholds
+{
+    public class ThresholdTests
+    {
+        [Theory]
+        [InlineData("1.5%", 1.5 / 100.0, ThresholdUnit.Ratio)]
+        [InlineData("1.5ns", 1.5, ThresholdUnit.Nanoseconds)]
+        [InlineData("1\u03BCs", 1.0, ThresholdUnit.Microseconds)]
+        [InlineData("10ms", 10.0, ThresholdUnit.Milliseconds)]
+        [InlineData("10,000s", 10_000.0, ThresholdUnit.Seconds)]
+        [InlineData("10,000.5m", 10_000.5, ThresholdUnit.Minutes)]
+        public void ParseTest(string input, double expectedValue, ThresholdUnit expectedUnit)
+        {
+            Assert.True(Threshold.TryParse(input, out var parsed));
+            Assert.Equal(Threshold.Create(expectedUnit, expectedValue), parsed);
+        }
+
+        [Theory]
+        [InlineData("1,5%", 1.5 / 100.0, ThresholdUnit.Ratio)]
+        [InlineData("1,5ns", 1.5, ThresholdUnit.Nanoseconds)]
+        [InlineData("1\u03BCs", 1.0, ThresholdUnit.Microseconds)]
+        [InlineData("10ms", 10.0, ThresholdUnit.Milliseconds)]
+        [InlineData("10000s", 10_000.0, ThresholdUnit.Seconds)]
+        [InlineData("10000,5m", 10_000.5, ThresholdUnit.Minutes)]
+        public void ParseTestDifferentFormat(string input, double expectedValue, ThresholdUnit expectedUnit)
+        {
+            var numberStyle = NumberStyles.Any;
+            var frenchFormat = new CultureInfo("fr-FR");
+
+            Assert.True(Threshold.TryParse(input, numberStyle, frenchFormat, out var parsed));
+            Assert.Equal(Threshold.Create(expectedUnit, expectedValue), parsed);
+        }
+
+        [Fact]
+        public void ParseTestInvalidFormat()
+        {
+            var numberStyle = NumberStyles.Any;
+            var frenchFormat = new CultureInfo("fr-FR");
+
+            Assert.False(Threshold.TryParse("1,000.5s", numberStyle, frenchFormat, out _));
+            Assert.False(Threshold.TryParse("1.5s", numberStyle, frenchFormat, out _));
+        }
+    }
+}

--- a/src/Perfolizer/Perfolizer/Horology/Frequency.cs
+++ b/src/Perfolizer/Perfolizer/Horology/Frequency.cs
@@ -9,7 +9,7 @@ namespace Perfolizer.Horology
     public struct Frequency : IEquatable<Frequency>, IComparable<Frequency>
     {
         private const string DefaultFormat = "";
-        
+
         [PublicAPI] public double Hertz { get; }
 
         [PublicAPI] public Frequency(double hertz) => Hertz = hertz;
@@ -51,17 +51,39 @@ namespace Perfolizer.Horology
         [PublicAPI, Pure] public static bool operator ==(Frequency a, Frequency b) => a.Hertz.Equals(b.Hertz);
         [PublicAPI, Pure] public static bool operator !=(Frequency a, Frequency b) => !a.Hertz.Equals(b.Hertz);
 
-        [PublicAPI, Pure] public static bool TryParse(string s, FrequencyUnit unit, out Frequency freq)
+        [PublicAPI, Pure]
+        public static bool TryParse(string s, FrequencyUnit unit, out Frequency freq)
         {
-            bool success = double.TryParse(s, NumberStyles.Any, DefaultCultureInfo.Instance, out double result);
+            return TryParse(s, unit, NumberStyles.Any, DefaultCultureInfo.Instance, out freq);
+        }
+
+        [PublicAPI, Pure]
+        public static bool TryParse(string s, FrequencyUnit unit, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+        {
+            bool success = double.TryParse(s, numberStyle, formatProvider, out double result);
             freq = new Frequency(result, unit);
             return success;
         }
 
         [PublicAPI, Pure] public static bool TryParseHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.Hz, out freq);
+        [PublicAPI, Pure]
+        public static bool TryParseHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+            => TryParse(s, FrequencyUnit.Hz, numberStyle, formatProvider, out freq);
+
         [PublicAPI, Pure] public static bool TryParseKHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.KHz, out freq);
+        [PublicAPI, Pure]
+        public static bool TryParseKHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+            => TryParse(s, FrequencyUnit.KHz, numberStyle, formatProvider, out freq);
+
         [PublicAPI, Pure] public static bool TryParseMHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.MHz, out freq);
+        [PublicAPI, Pure]
+        public static bool TryParseMHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+            => TryParse(s, FrequencyUnit.MHz, numberStyle, formatProvider, out freq);
+
         [PublicAPI, Pure] public static bool TryParseGHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.GHz, out freq);
+        [PublicAPI, Pure]
+        public static bool TryParseGHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+            => TryParse(s, FrequencyUnit.GHz, numberStyle, formatProvider, out freq);
 
         [PublicAPI, Pure, NotNull]
         public string ToString(
@@ -92,14 +114,14 @@ namespace Perfolizer.Horology
 
             return unitValue.ToString(format, formatProvider);
         }
-        
+
         [PublicAPI, Pure, NotNull] public override string ToString() => ToString(DefaultFormat);
-        
+
         public bool Equals(Frequency other) => Hertz.Equals(other.Hertz);
         public bool Equals(Frequency other, double hertzEpsilon) => Math.Abs(Hertz - other.Hertz) < hertzEpsilon;
         public override bool Equals(object obj) => obj is Frequency other && Equals(other);
         public override int GetHashCode() => Hertz.GetHashCode();
-        public int CompareTo(Frequency other)=> Hertz.CompareTo(other.Hertz);
+        public int CompareTo(Frequency other) => Hertz.CompareTo(other.Hertz);
 
     }
 }

--- a/src/Perfolizer/Perfolizer/Mathematics/Thresholds/Threshold.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Thresholds/Threshold.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using Perfolizer.Common;
 using Perfolizer.Horology;
 using Perfolizer.Mathematics.SignificanceTesting;
 
@@ -27,6 +29,11 @@ namespace Perfolizer.Mathematics.Thresholds
 
         public static bool TryParse(string input, out Threshold parsed)
         {
+            return TryParse(input, NumberStyles.Any, DefaultCultureInfo.Instance, out parsed);
+        }
+
+        public static bool TryParse(string input, NumberStyles numberStyle, IFormatProvider formatProvider, out Threshold parsed)
+        {
             if (string.IsNullOrWhiteSpace(input))
             {
                 parsed = default;
@@ -37,7 +44,8 @@ namespace Perfolizer.Mathematics.Thresholds
             var number = new string(trimmed.TakeWhile(c => char.IsDigit(c) || c == '.' || c == ',').ToArray());
             var unit = new string(trimmed.SkipWhile(c => char.IsDigit(c) || c == '.' || c == ',' || char.IsWhiteSpace(c)).ToArray());
 
-            if (!double.TryParse(number, out var parsedValue) || !ThresholdUnitExtensions.ShortNameToUnit.TryGetValue(unit, out var parsedUnit))
+            if (!double.TryParse(number, numberStyle, formatProvider, out var parsedValue)
+                || !ThresholdUnitExtensions.ShortNameToUnit.TryGetValue(unit, out var parsedUnit))
             {
                 parsed = default;
                 return false;


### PR DESCRIPTION
As described in issue #6, this PR adds overloads to the `Threshold.TryParse` and `Frequency.TryParse*` methods providing two additional parameters usually found on .NET TryParse methods: a `NumberStyles` parameter and an `IFormatProvider` parameter (for defining a custom `CultureInfo` for example).

Tests have been added for the new overloads of the `Frequency.TryParse*` methods, however I did not find a suitable location in the testsuite for the `Threshold.TryParse` method, where should it be added and how should it be tested?