### PR TITLE
Multi-target to .NET Standard 2.1 and remove the dependency to `System.Memory` from that.

### DIFF
--- a/src/Perfolizer/Perfolizer/Mathematics/Functions/QuantileCompareFunction.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Functions/QuantileCompareFunction.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Perfolizer.Common;
 using Perfolizer.Mathematics.Common;
 using Perfolizer.Mathematics.QuantileEstimators;
+using Range = Perfolizer.Mathematics.Common.Range;
 
 namespace Perfolizer.Mathematics.Functions
 {

--- a/src/Perfolizer/Perfolizer/Perfolizer.csproj
+++ b/src/Perfolizer/Perfolizer/Perfolizer.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <Description>Performance analysis toolkit</Description>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="All" />
-        <PackageReference Include="System.Memory" Version="4.5.3" />
+        <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.5.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It was asked by https://github.com/dotnet/msbuild/commit/20cdf6ff1f617fc6d486c170dff95df0300676e3#r73773876.