### PR TITLE
Add nullable attributes

### DIFF
--- a/src/Perfolizer/Perfolizer.Tool/Base/DistributionCompareOptions.cs
+++ b/src/Perfolizer/Perfolizer.Tool/Base/DistributionCompareOptions.cs
@@ -50,7 +50,7 @@ namespace Perfolizer.Tool.Base
             }
             else
             {
-                var probabilities = Probability.ToProbabilities(options.ConvertStringToArray(options.Probabilities, "probabilities"))!;
+                var probabilities = Probability.ToProbabilities(options.ConvertStringToArray(options.Probabilities, "probabilities"));
                 Console.WriteLine(string.Join(";", function.GetValues(x, y, probabilities)));
             }
         }

--- a/src/Perfolizer/Perfolizer.Tool/QuantileEstimatorOptions.cs
+++ b/src/Perfolizer/Perfolizer.Tool/QuantileEstimatorOptions.cs
@@ -49,7 +49,7 @@ namespace Perfolizer.Tool
             };
 
             var data = options.GetSourceArray();
-            var probabilities = Probability.ToProbabilities(options.ConvertStringToArray(options.Probabilities!, "probabilities"))!;
+            var probabilities = Probability.ToProbabilities(options.ConvertStringToArray(options.Probabilities!, "probabilities"));
 
             var quantiles = estimator.GetQuantiles(data, probabilities);
             Console.WriteLine(string.Join(options.SourceSeparator, quantiles));

--- a/src/Perfolizer/Perfolizer/Attributes/NullableAttributes.cs
+++ b/src/Perfolizer/Perfolizer/Attributes/NullableAttributes.cs
@@ -1,0 +1,196 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NETSTANDARD2_1
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+#endif
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+}

--- a/src/Perfolizer/Perfolizer/Attributes/NullableAttributes.cs
+++ b/src/Perfolizer/Perfolizer/Attributes/NullableAttributes.cs
@@ -6,48 +6,23 @@ namespace System.Diagnostics.CodeAnalysis
 #if !NETSTANDARD2_1
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class AllowNullAttribute : Attribute { }
+    internal sealed class AllowNullAttribute : Attribute { }
 
     /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class DisallowNullAttribute : Attribute { }
+    internal sealed class DisallowNullAttribute : Attribute { }
 
     /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class MaybeNullAttribute : Attribute { }
+    internal sealed class MaybeNullAttribute : Attribute { }
 
     /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class NotNullAttribute : Attribute { }
+    internal sealed class NotNullAttribute : Attribute { }
 
     /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class MaybeNullWhenAttribute : Attribute
+    internal sealed class MaybeNullWhenAttribute : Attribute
     {
         /// <summary>Initializes the attribute with the specified return value condition.</summary>
         /// <param name="returnValue">
@@ -61,12 +36,7 @@ namespace System.Diagnostics.CodeAnalysis
 
     /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class NotNullWhenAttribute : Attribute
+    internal sealed class NotNullWhenAttribute : Attribute
     {
         /// <summary>Initializes the attribute with the specified return value condition.</summary>
         /// <param name="returnValue">
@@ -80,12 +50,7 @@ namespace System.Diagnostics.CodeAnalysis
 
     /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class NotNullIfNotNullAttribute : Attribute
+    internal sealed class NotNullIfNotNullAttribute : Attribute
     {
         /// <summary>Initializes the attribute with the associated parameter name.</summary>
         /// <param name="parameterName">
@@ -99,21 +64,11 @@ namespace System.Diagnostics.CodeAnalysis
 
     /// <summary>Applied to a method that will never return under any circumstance.</summary>
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class DoesNotReturnAttribute : Attribute { }
+    internal sealed class DoesNotReturnAttribute : Attribute { }
 
     /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class DoesNotReturnIfAttribute : Attribute
+    internal sealed class DoesNotReturnIfAttribute : Attribute
     {
         /// <summary>Initializes the attribute with the specified parameter value.</summary>
         /// <param name="parameterValue">
@@ -129,12 +84,7 @@ namespace System.Diagnostics.CodeAnalysis
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class MemberNotNullAttribute : Attribute
+    internal sealed class MemberNotNullAttribute : Attribute
     {
         /// <summary>Initializes the attribute with a field or property member.</summary>
         /// <param name="member">
@@ -154,12 +104,7 @@ namespace System.Diagnostics.CodeAnalysis
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-#if SYSTEM_PRIVATE_CORELIB
-    public
-#else
-    internal
-#endif
-        sealed class MemberNotNullWhenAttribute : Attribute
+    internal sealed class MemberNotNullWhenAttribute : Attribute
     {
         /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
         /// <param name="returnValue">

--- a/src/Perfolizer/Perfolizer/Common/Assertion.cs
+++ b/src/Perfolizer/Perfolizer/Common/Assertion.cs
@@ -2,20 +2,21 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Perfolizer.Exceptions;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Perfolizer.Common
 {
     internal static class Assertion
     {
         [AssertionMethod]
-        public static void NotNull(string name, object? value)
+        public static void NotNull(string name, [NotNull] object? value)
         {
             if (value == null)
                 throw new ArgumentNullException(name, $"{name} can't be null");
         }
 
         [AssertionMethod]
-        public static void NotNullOrEmpty<T>(string name, IReadOnlyList<T>? values)
+        public static void NotNullOrEmpty<T>(string name, [NotNull] IReadOnlyList<T>? values)
         {
             if (values == null)
                 throw new ArgumentNullException(name, $"{name} can't be null");
@@ -27,8 +28,8 @@ namespace Perfolizer.Common
         public static void ItemNotNull<T>(string name, IReadOnlyList<T> values)
         {
             for (int i = 0; i < values.Count; i++)
-                if (values[i] == null)
-                    throw new ArgumentNullException($"{name}[{i}] == null, but {name} should not contain null items");
+                if (values[i] is null)
+                    throw new ArgumentNullException($"{name}[{i}] is null, but {name} should not contain null items");
         }
 
         [AssertionMethod]
@@ -160,7 +161,7 @@ namespace Perfolizer.Common
         }
 
         [AssertionMethod]
-        public static void NonWeighted(string name, Sample sample)
+        public static void NonWeighted(string name, [NotNull] Sample? sample)
         {
             NotNull(name, sample);
             if (sample.IsWeighted)

--- a/src/Perfolizer/Perfolizer/Common/StringBuilderExtensions.cs
+++ b/src/Perfolizer/Perfolizer/Common/StringBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -6,6 +7,7 @@ namespace Perfolizer.Common
 {
     internal static class StringBuilderExtensions
     {
+        [return: NotNullIfNotNull("builder")]
         public static StringBuilder? TrimEnd(this StringBuilder? builder, params char[] trimChars)
         {
             if (builder == null)

--- a/src/Perfolizer/Perfolizer/Horology/Frequency.cs
+++ b/src/Perfolizer/Perfolizer/Horology/Frequency.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using JetBrains.Annotations;
 using Perfolizer.Common;
@@ -119,7 +120,7 @@ namespace Perfolizer.Horology
 
         public bool Equals(Frequency other) => Hertz.Equals(other.Hertz);
         public bool Equals(Frequency other, double hertzEpsilon) => Math.Abs(Hertz - other.Hertz) < hertzEpsilon;
-        public override bool Equals(object obj) => obj is Frequency other && Equals(other);
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is Frequency other && Equals(other);
         public override int GetHashCode() => Hertz.GetHashCode();
         public int CompareTo(Frequency other) => Hertz.CompareTo(other.Hertz);
 

--- a/src/Perfolizer/Perfolizer/Horology/Frequency.cs
+++ b/src/Perfolizer/Perfolizer/Horology/Frequency.cs
@@ -53,37 +53,37 @@ namespace Perfolizer.Horology
         [PublicAPI, Pure] public static bool operator !=(Frequency a, Frequency b) => !a.Hertz.Equals(b.Hertz);
 
         [PublicAPI, Pure]
-        public static bool TryParse(string s, FrequencyUnit unit, out Frequency freq)
+        public static bool TryParse([NotNullWhen(true)] string? s, FrequencyUnit unit, out Frequency freq)
         {
             return TryParse(s, unit, NumberStyles.Any, DefaultCultureInfo.Instance, out freq);
         }
 
         [PublicAPI, Pure]
-        public static bool TryParse(string s, FrequencyUnit unit, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+        public static bool TryParse([NotNullWhen(true)] string? s, FrequencyUnit unit, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
         {
             bool success = double.TryParse(s, numberStyle, formatProvider, out double result);
             freq = new Frequency(result, unit);
             return success;
         }
 
-        [PublicAPI, Pure] public static bool TryParseHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.Hz, out freq);
+        [PublicAPI, Pure] public static bool TryParseHz([NotNullWhen(true)] string? s, out Frequency freq) => TryParse(s, FrequencyUnit.Hz, out freq);
         [PublicAPI, Pure]
-        public static bool TryParseHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+        public static bool TryParseHz([NotNullWhen(true)] string? s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
             => TryParse(s, FrequencyUnit.Hz, numberStyle, formatProvider, out freq);
 
-        [PublicAPI, Pure] public static bool TryParseKHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.KHz, out freq);
+        [PublicAPI, Pure] public static bool TryParseKHz([NotNullWhen(true)] string? s, out Frequency freq) => TryParse(s, FrequencyUnit.KHz, out freq);
         [PublicAPI, Pure]
-        public static bool TryParseKHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+        public static bool TryParseKHz([NotNullWhen(true)] string? s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
             => TryParse(s, FrequencyUnit.KHz, numberStyle, formatProvider, out freq);
 
-        [PublicAPI, Pure] public static bool TryParseMHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.MHz, out freq);
+        [PublicAPI, Pure] public static bool TryParseMHz([NotNullWhen(true)] string? s, out Frequency freq) => TryParse(s, FrequencyUnit.MHz, out freq);
         [PublicAPI, Pure]
-        public static bool TryParseMHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+        public static bool TryParseMHz([NotNullWhen(true)] string? s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
             => TryParse(s, FrequencyUnit.MHz, numberStyle, formatProvider, out freq);
 
-        [PublicAPI, Pure] public static bool TryParseGHz(string s, out Frequency freq) => TryParse(s, FrequencyUnit.GHz, out freq);
+        [PublicAPI, Pure] public static bool TryParseGHz([NotNullWhen(true)] string? s, out Frequency freq) => TryParse(s, FrequencyUnit.GHz, out freq);
         [PublicAPI, Pure]
-        public static bool TryParseGHz(string s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
+        public static bool TryParseGHz([NotNullWhen(true)] string? s, NumberStyles numberStyle, IFormatProvider formatProvider, out Frequency freq)
             => TryParse(s, FrequencyUnit.GHz, numberStyle, formatProvider, out freq);
 
         [PublicAPI, Pure]

--- a/src/Perfolizer/Perfolizer/Horology/TimeInterval.cs
+++ b/src/Perfolizer/Perfolizer/Horology/TimeInterval.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Perfolizer.Common;
 
@@ -91,7 +92,7 @@ namespace Perfolizer.Horology
         public int CompareTo(TimeInterval other) => Nanoseconds.CompareTo(other.Nanoseconds);
         public bool Equals(TimeInterval other) => Nanoseconds.Equals(other.Nanoseconds);
         public bool Equals(TimeInterval other, double nanosecondEpsilon) => Math.Abs(other.Nanoseconds - Nanoseconds) < nanosecondEpsilon;
-        public override bool Equals(object obj) => obj is TimeInterval other && Equals(other);
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is TimeInterval other && Equals(other);
         public override int GetHashCode() => Nanoseconds.GetHashCode();
     }
 }

--- a/src/Perfolizer/Perfolizer/Horology/TimeUnit.cs
+++ b/src/Perfolizer/Perfolizer/Horology/TimeUnit.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 
 namespace Perfolizer.Horology
 {
-    public class TimeUnit : IEquatable<TimeUnit>
+    public class TimeUnit : IEquatable<TimeUnit?>
     {
         public string Name { get; }
 
@@ -49,7 +50,7 @@ namespace Perfolizer.Horology
         public static double Convert(double value, TimeUnit from, TimeUnit? to) =>
             value * from.NanosecondAmount / (to ?? GetBestTimeUnit(value)).NanosecondAmount;
 
-        public bool Equals(TimeUnit other)
+        public bool Equals([NotNullWhen(true)] TimeUnit? other)
         {
             if (ReferenceEquals(null, other))
                 return false;
@@ -58,7 +59,7 @@ namespace Perfolizer.Horology
             return Equals(Name, other.Name) && string.Equals(Description, other.Description) && NanosecondAmount == other.NanosecondAmount;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;

--- a/src/Perfolizer/Perfolizer/Mathematics/Common/ConfidenceInterval.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Common/ConfidenceInterval.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Perfolizer.Common;
 
@@ -63,7 +64,7 @@ namespace Perfolizer.Mathematics.Common
                    comparer.Equals(ConfidenceLevel, other.ConfidenceLevel);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is ConfidenceInterval other && Equals(other);
         }

--- a/src/Perfolizer/Perfolizer/Mathematics/Common/Probability.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Common/Probability.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Perfolizer.Common;
 
 namespace Perfolizer.Mathematics.Common
@@ -60,7 +61,8 @@ namespace Perfolizer.Mathematics.Common
         {
             return Value.CompareTo(other.Value);
         }
-        
+
+        [return: NotNullIfNotNull("values")]
         public static Probability[]? ToProbabilities(double[]? values)
         {
             if (values == null)

--- a/src/Perfolizer/Perfolizer/Mathematics/Common/Probability.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Common/Probability.cs
@@ -47,7 +47,7 @@ namespace Perfolizer.Mathematics.Common
             return Value.Equals(other.Value);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is Probability other && Equals(other);
         }

--- a/src/Perfolizer/Perfolizer/Mathematics/Histograms/DensityHistogram.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Histograms/DensityHistogram.cs
@@ -27,7 +27,7 @@ namespace Perfolizer.Mathematics.Histograms
                     bin.Lower.ToString(format),
                     bin.Upper.ToString(format),
                     bin.Height.ToString(format)));
-            return builder.TrimEnd()!.ToString();
+            return builder.TrimEnd().ToString();
         }
     }
 }

--- a/src/Perfolizer/Perfolizer/Mathematics/Histograms/QuantileRespectfulDensityHistogramBuilder.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Histograms/QuantileRespectfulDensityHistogramBuilder.cs
@@ -29,7 +29,7 @@ namespace Perfolizer.Mathematics.Histograms
                 throw new WeightedSampleNotSupportedException();
 
             var probabilities =
-                Probability.ToProbabilities(new ArithmeticProgressionSequence(0, 1.0 / binCount).GenerateArray(binCount + 1))!;
+                Probability.ToProbabilities(new ArithmeticProgressionSequence(0, 1.0 / binCount).GenerateArray(binCount + 1));
             double[] quantiles = quantileEstimator.GetQuantiles(sample, probabilities);
 
             var bins = new List<DensityHistogramBin>(binCount);

--- a/src/Perfolizer/Perfolizer/Mathematics/Thresholds/AbsoluteTimeThreshold.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Thresholds/AbsoluteTimeThreshold.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Perfolizer.Common;
 using Perfolizer.Horology;
 
 namespace Perfolizer.Mathematics.Thresholds
 {
-    public class AbsoluteTimeThreshold : AbsoluteThreshold, IEquatable<AbsoluteTimeThreshold>
+    public class AbsoluteTimeThreshold : AbsoluteThreshold, IEquatable<AbsoluteTimeThreshold?>
     {
         private readonly TimeInterval timeInterval;
 
@@ -12,9 +13,9 @@ namespace Perfolizer.Mathematics.Thresholds
 
         public override string ToString() => timeInterval.ToString("0.##");
 
-        public bool Equals(AbsoluteTimeThreshold other) => other != null && timeInterval.Equals(other.timeInterval);
+        public bool Equals([NotNullWhen(true)] AbsoluteTimeThreshold? other) => other != null && timeInterval.Equals(other.timeInterval);
 
-        public override bool Equals(object obj) => obj is AbsoluteTimeThreshold other && Equals(other);
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is AbsoluteTimeThreshold other && Equals(other);
 
         public override int GetHashCode() => timeInterval.GetHashCode();
     }

--- a/src/Perfolizer/Perfolizer/Mathematics/Thresholds/RelativeThreshold.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Thresholds/RelativeThreshold.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Perfolizer.Mathematics.Thresholds
 {
-    public class RelativeThreshold : Threshold, IEquatable<RelativeThreshold>
+    public class RelativeThreshold : Threshold, IEquatable<RelativeThreshold?>
     {
         public static readonly Threshold Zero = new RelativeThreshold(0);
         public static readonly Threshold Default = new RelativeThreshold(0.01);
@@ -19,9 +20,9 @@ namespace Perfolizer.Mathematics.Thresholds
 
         public override string ToString() => ratio * 100 + ThresholdUnit.Ratio.ToShortName();
 
-        public bool Equals(RelativeThreshold other) => other != null && ratio.Equals(other.ratio);
+        public bool Equals([NotNullWhen(true)] RelativeThreshold? other) => other != null && ratio.Equals(other.ratio);
 
-        public override bool Equals(object obj) => obj is RelativeThreshold other && Equals(other);
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is RelativeThreshold other && Equals(other);
 
         public override int GetHashCode() => ratio.GetHashCode();
     }

--- a/src/Perfolizer/Perfolizer/Mathematics/Thresholds/Threshold.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Thresholds/Threshold.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Perfolizer.Common;
@@ -27,12 +28,12 @@ namespace Perfolizer.Mathematics.Thresholds
         public abstract double GetValue(IReadOnlyList<double> values);
         public abstract bool IsZero();
 
-        public static bool TryParse(string input, out Threshold? parsed)
+        public static bool TryParse([NotNullWhen(true)] string? input, [NotNullWhen(true)] out Threshold? parsed)
         {
             return TryParse(input, NumberStyles.Any, DefaultCultureInfo.Instance, out parsed);
         }
 
-        public static bool TryParse(string input, NumberStyles numberStyle, IFormatProvider formatProvider, out Threshold? parsed)
+        public static bool TryParse([NotNullWhen(true)] string? input, NumberStyles numberStyle, IFormatProvider formatProvider, [NotNullWhen(true)] out Threshold? parsed)
         {
             if (string.IsNullOrWhiteSpace(input))
             {


### PR DESCRIPTION
Used this document: https://github.com/dotnet/runtime/blob/2b0e2785e546a38e9bf401d71650514fa00cf1b8/docs/coding-guidelines/api-guidelines/nullability.md

### In short:
**DO** implement `IComparable<T?>` instead of `IComparable<T>` on a reference type `T`.
**DO** implement `IEquatable<T?>` instead of `IEquatable<T>` on a reference type `T`. e.g.
```C#
public sealed class Version : IComparable<Version?>, IEquatable<Version?>
```

**DO** add `[NotNullWhen(true)]` to nullable arguments of `Try` methods that will definitively be non-null if the method returns true.

**DO** add `[NotNullWhen(true)]` to overrides of `public virtual bool Equals(object? obj)`

**DO** add `[return: NotNullIfNotNull(string)]` if a method would not return null in case an argument passed evaluated to non-null, pass that argument name as string.