### PR TITLE
Make structs readonly

### DIFF
--- a/src/Perfolizer/Perfolizer/Horology/ClockSpan.cs
+++ b/src/Perfolizer/Perfolizer/Horology/ClockSpan.cs
@@ -3,7 +3,7 @@ using JetBrains.Annotations;
 
 namespace Perfolizer.Horology
 {
-    public struct ClockSpan
+    public readonly struct ClockSpan
     {
         private readonly long startTimestamp, endTimestamp;
         private readonly Frequency frequency;

--- a/src/Perfolizer/Perfolizer/Horology/Frequency.cs
+++ b/src/Perfolizer/Perfolizer/Horology/Frequency.cs
@@ -6,7 +6,7 @@ using Perfolizer.Common;
 namespace Perfolizer.Horology
 {
     [PublicAPI]
-    public struct Frequency : IEquatable<Frequency>, IComparable<Frequency>
+    public readonly struct Frequency : IEquatable<Frequency>, IComparable<Frequency>
     {
         private const string DefaultFormat = "";
 

--- a/src/Perfolizer/Perfolizer/Horology/StartedClock.cs
+++ b/src/Perfolizer/Perfolizer/Horology/StartedClock.cs
@@ -1,6 +1,8 @@
-﻿namespace Perfolizer.Horology
+﻿using JetBrains.Annotations;
+
+namespace Perfolizer.Horology
 {
-    public struct StartedClock
+    public readonly struct StartedClock
     {
         private readonly IClock clock;
         private readonly long startTimestamp;
@@ -11,7 +13,7 @@
             this.startTimestamp = startTimestamp;
         }
 
-        public ClockSpan GetElapsed() => new ClockSpan(startTimestamp, clock.GetTimestamp(), clock.Frequency);
+        [Pure] public ClockSpan GetElapsed() => new ClockSpan(startTimestamp, clock.GetTimestamp(), clock.Frequency);
 
         public override string ToString() => $"StartedClock({clock.Title}, {startTimestamp} ticks)";
     }


### PR DESCRIPTION
[TimeInternal](https://github.com/AndreyAkinshin/perfolizer/blob/master/src/Perfolizer/Perfolizer/Horology/TimeInterval.cs) is a readonly struct, it seems these structs should be readonly too.

In [BenchmarkRunnerClean](https://github.com/dotnet/BenchmarkDotNet/blob/90c82bb1e3188787471076a2604017103f93a361/src/BenchmarkDotNet/Running/BenchmarkRunnerClean.cs), `StartedClock` is passed to methods using the `in` keyword, which means that it creates a hidden copy each time it is called.

Note:
`struct -> readonly struct` is not breaking change.
`readonly struct -> struct` is breaking change.