### PR TITLE
Fix broken reference to "Trinal statistical thresholds" post

### DIFF
--- a/src/Perfolizer/Perfolizer/Metrology/Threshold.cs
+++ b/src/Perfolizer/Perfolizer/Metrology/Threshold.cs
@@ -6,7 +6,7 @@ using Perfolizer.Mathematics.GenericEstimators;
 namespace Perfolizer.Metrology;
 
 /// <summary>
-/// https://aakinshin.net/posts/trinal-thresholds/
+/// https://aakinshin.net/posts/post-trinal-thresholds/
 /// </summary>
 public class Threshold(params ISpecificMeasurementValue[] thresholdValues) : IWithUnits, IEquatable<Threshold>
 {


### PR DESCRIPTION
Just came across a broken link in a comment and tried to find the original post that the URL was referring to.