### PR TITLE
Apply `AggressiveOptimization` to clocks

### DIFF
--- a/src/Perfolizer/Perfolizer/Helpers/JitHelper.cs
+++ b/src/Perfolizer/Perfolizer/Helpers/JitHelper.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Perfolizer.Helpers;
+
+internal static class JitHelper
+{
+    // This is used to ensure clock methods are immediately promoted to tier 1 JIT, and are not re-jitted,
+    // to avoid any tiered-JIT-related variance in time measurements.
+    // AggressiveOptimization is not available in netstandard2.0, so just use the value casted to enum.
+    internal const MethodImplOptions AggressiveOptimizationOption = (MethodImplOptions) 512;
+}

--- a/src/Perfolizer/Perfolizer/Horology/ClockExtensions.cs
+++ b/src/Perfolizer/Perfolizer/Horology/ClockExtensions.cs
@@ -1,8 +1,12 @@
+using Perfolizer.Helpers;
+using System.Runtime.CompilerServices;
+
 namespace Perfolizer.Horology;
 
 public static class ClockExtensions
 {
     public static TimeInterval GetResolution(this IClock clock) => clock.Frequency.ToResolution();
 
+    [MethodImpl(JitHelper.AggressiveOptimizationOption)]
     public static StartedClock Start(this IClock clock) => new StartedClock(clock, clock.GetTimestamp());
 }

--- a/src/Perfolizer/Perfolizer/Horology/DateTimeClock.cs
+++ b/src/Perfolizer/Perfolizer/Horology/DateTimeClock.cs
@@ -1,3 +1,6 @@
+using Perfolizer.Helpers;
+using System.Runtime.CompilerServices;
+
 namespace Perfolizer.Horology;
 
 internal class DateTimeClock : IClock
@@ -6,6 +9,11 @@ internal class DateTimeClock : IClock
 
     public string Title => "DateTime";
     public bool IsAvailable => true;
-    public Frequency Frequency => new Frequency(TicksPerSecond);
+    public Frequency Frequency
+    {
+        [MethodImpl(JitHelper.AggressiveOptimizationOption)]
+        get => new Frequency(TicksPerSecond);
+    }
+    [MethodImpl(JitHelper.AggressiveOptimizationOption)]
     public long GetTimestamp() => DateTime.UtcNow.Ticks;
 }

--- a/src/Perfolizer/Perfolizer/Horology/StartedClock.cs
+++ b/src/Perfolizer/Perfolizer/Horology/StartedClock.cs
@@ -1,4 +1,6 @@
 ﻿using JetBrains.Annotations;
+using Perfolizer.Helpers;
+using System.Runtime.CompilerServices;
 
 namespace Perfolizer.Horology;
 
@@ -7,13 +9,16 @@ public readonly struct StartedClock
     private readonly IClock clock;
     private readonly long startTimestamp;
 
+    [MethodImpl(JitHelper.AggressiveOptimizationOption)]
     public StartedClock(IClock clock, long startTimestamp)
     {
         this.clock = clock;
         this.startTimestamp = startTimestamp;
     }
 
-    [Pure] public ClockSpan GetElapsed() => new ClockSpan(startTimestamp, clock.GetTimestamp(), clock.Frequency);
+    [MethodImpl(JitHelper.AggressiveOptimizationOption)]
+    [Pure]
+    public ClockSpan GetElapsed() => new ClockSpan(startTimestamp, clock.GetTimestamp(), clock.Frequency);
 
     public override string ToString() => $"StartedClock({clock.Title}, {startTimestamp} ticks)";
 }

--- a/src/Perfolizer/Perfolizer/Horology/StopwatchClock.cs
+++ b/src/Perfolizer/Perfolizer/Horology/StopwatchClock.cs
@@ -1,4 +1,6 @@
+using Perfolizer.Helpers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Perfolizer.Horology;
 
@@ -6,6 +8,11 @@ internal class StopwatchClock : IClock
 {
     public string Title => "Stopwatch";
     public bool IsAvailable => true;
-    public Frequency Frequency => new Frequency(Stopwatch.Frequency);
+    public Frequency Frequency
+    {
+        [MethodImpl(JitHelper.AggressiveOptimizationOption)]
+        get => new Frequency(Stopwatch.Frequency);
+    }
+    [MethodImpl(JitHelper.AggressiveOptimizationOption)]
     public long GetTimestamp() => Stopwatch.GetTimestamp();
 }

--- a/src/Perfolizer/Perfolizer/Horology/WindowsClock.cs
+++ b/src/Perfolizer/Perfolizer/Horology/WindowsClock.cs
@@ -1,3 +1,5 @@
+using Perfolizer.Helpers;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -45,8 +47,13 @@ internal class WindowsClock : IClock
 
     public string Title => "Windows";
     public bool IsAvailable => GlobalIsAvailable;
-    public Frequency Frequency => new Frequency(GlobalFrequency);
+    public Frequency Frequency
+    {
+        [MethodImpl(JitHelper.AggressiveOptimizationOption)]
+        get => new Frequency(GlobalFrequency);
+    }
 
+    [MethodImpl(JitHelper.AggressiveOptimizationOption)]
     public long GetTimestamp()
     {
         QueryPerformanceCounter(out long value);


### PR DESCRIPTION
Eliminates tiered-JIT as a potential variable when time measurements are taken.