### PR TITLE
chore(deps): upgrade Pragmastat from 12.0.0 to 13.0.1

### DIFF
--- a/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/HarrellDavisQuantileEstimatorTests.cs
+++ b/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/HarrellDavisQuantileEstimatorTests.cs
@@ -312,7 +312,7 @@ public class HarrellDavisQuantileEstimatorTests : QuantileEstimatorTests
         );
 
         var estimator = HarrellDavisQuantileEstimator.Instance;
-        var probability = Probability.Half;
+        var probability = (Probability)0.5;
         var level = ConfidenceLevel.L90;
 
         var ci1 = estimator.QuantileConfidenceIntervalEstimator(sample1, probability).ConfidenceInterval(level);

--- a/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/HyndmanFanQuantileEstimatorTests.cs
+++ b/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/HyndmanFanQuantileEstimatorTests.cs
@@ -172,7 +172,7 @@ public class HyndmanFanQuantileEstimatorTests : QuantileEstimatorTests
     {
         Check(SimpleQuantileEstimator.Instance, new TestData(
             new double[] { 1, 1.5, 2, 2.5, 3, 2, 2.5, 3, 3.5, 3, 3.5, 4, 4, 4.5, 5 },
-            new[] { Probability.Half },
+            new[] { (Probability)0.5 },
             new double[] { 2 },
             new double[] { 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0 }));
     }

--- a/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/MovingQuantileEstimatorTestsBase.cs
+++ b/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/MovingQuantileEstimatorTestsBase.cs
@@ -80,7 +80,7 @@ public abstract class MovingQuantileEstimatorTestsBase
     [InlineData(10_000, 1023)]
     public void MovingSelectorMedianTest(int totalElementCount, int windowSize)
     {
-        DoTest(CreateEstimator(windowSize, Probability.Half), MovingQuantileEstimatorInitStrategy.QuantileApproximation,
+        DoTest(CreateEstimator(windowSize, (Probability)0.5), MovingQuantileEstimatorInitStrategy.QuantileApproximation,
             totalElementCount, windowSize, windowSize / 2, _ => 1.0);
     }
 

--- a/src/Perfolizer/Perfolizer/Mathematics/Distributions/ContinuousDistributions/LaplaceDistribution.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Distributions/ContinuousDistributions/LaplaceDistribution.cs
@@ -26,7 +26,7 @@ public class LaplaceDistribution : IContinuousDistribution
         ? Exp((x - Mu) / Sigma) / 2
         : 1 - Exp(-(x - Mu) / Sigma) / 2;
 
-    public double Quantile(Probability p) => p < Probability.Half
+    public double Quantile(Probability p) => p < (Probability)0.5
         ? Mu + Sigma * Log(2 * p)
         : Mu - Sigma * Log(2 - 2 * p);
 

--- a/src/Perfolizer/Perfolizer/Mathematics/Functions/QuantileCompareFunction.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Functions/QuantileCompareFunction.cs
@@ -53,7 +53,7 @@ public abstract class QuantileCompareFunction
         int count = quantizationCount ?? (int)Math.Round((right - left) / 0.01 + 1);
         var probabilities = new Probability[count];
         if (count == 1)
-            probabilities[0] = Probability.Half;
+            probabilities[0] = (Probability)0.5;
         else
             for (int i = 0; i < count; i++)
                 probabilities[i] = left + (right - left) / (count - 1) * i;

--- a/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/PartitioningHeapsMovingQuantileEstimator.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/PartitioningHeapsMovingQuantileEstimator.cs
@@ -22,7 +22,7 @@ namespace Perfolizer.Mathematics.QuantileEstimators;
 public class PartitioningHeapsMovingQuantileEstimator : ISequentialSpecificQuantileEstimator
 {
     private readonly int windowSize, k;
-    private readonly Probability probability;
+    private readonly Probability? probability;
     private readonly double[] h;
     private readonly int[] heapToElementIndex;
     private readonly int[] elementToHeapIndex;
@@ -39,7 +39,7 @@ public class PartitioningHeapsMovingQuantileEstimator : ISequentialSpecificQuant
 
         this.k = k;
         this.windowSize = windowSize;
-        probability = Probability.NaN;
+        probability = null;
         h = new double[windowSize];
         heapToElementIndex = new int[windowSize];
         elementToHeapIndex = new int[windowSize];
@@ -221,7 +221,7 @@ public class PartitioningHeapsMovingQuantileEstimator : ISequentialSpecificQuant
     {
         if (totalElementCount == 0)
             throw new EmptySequenceException();
-        if (hyndmanFanType != null && !double.IsNaN(probability))
+        if (hyndmanFanType != null && probability.HasValue)
         {
             if (totalElementCount < windowSize)
                 throw new InvalidOperationException($"Sequence should contain at least {windowSize} elements");
@@ -234,7 +234,7 @@ public class PartitioningHeapsMovingQuantileEstimator : ISequentialSpecificQuant
                 throw new InvalidOperationException();
             }
 
-            return HyndmanFanHelper.Evaluate(hyndmanFanType.Value, windowSize, probability, GetValue);
+            return HyndmanFanHelper.Evaluate(hyndmanFanType.Value, windowSize, probability.Value, GetValue);
         }
 
         if (initStrategy == MovingQuantileEstimatorInitStrategy.OrderStatistics && k >= totalElementCount)

--- a/src/Perfolizer/Perfolizer/Perfolizer.csproj
+++ b/src/Perfolizer/Perfolizer/Perfolizer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" PrivateAssets="All" />
-    <PackageReference Include="Pragmastat" Version="12.0.0" />
+    <PackageReference Include="Pragmastat" Version="13.0.1" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.5.5"/>
   </ItemGroup>
 


### PR DESCRIPTION
Upgrade Pragmastat 12.0.0 → 13.0.1. The only API break that touches us is the removal of `Probability.Half`/`Probability.NaN`, handled with `(Probability)0.5` and a nullable `Probability?` sentinel.