### PR TITLE
fix: resolve compiler warnings (nullable + obsolete)

### DIFF
--- a/src/Perfolizer/Perfolizer.Demo/OutlierDetectorDemo.cs
+++ b/src/Perfolizer/Perfolizer.Demo/OutlierDetectorDemo.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Demo intentionally exercises obsolete MAD-based outlier detectors
 using Perfolizer.Mathematics.OutlierDetection;
 using Perfolizer.Mathematics.QuantileEstimators;
 using Perfolizer.Mathematics.ScaleEstimators;

--- a/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/ExtendedP2QuantileEstimatorTests.cs
+++ b/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/ExtendedP2QuantileEstimatorTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Uses obsolete MedianAbsoluteDeviationEstimator for error normalization
 using JetBrains.Annotations;
 using Perfolizer.Extensions;
 using Perfolizer.Mathematics.Common;

--- a/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/P2QuantileEstimatorTests.cs
+++ b/src/Perfolizer/Perfolizer.SimulationTests/QuantileEstimators/P2QuantileEstimatorTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // Uses obsolete MedianAbsoluteDeviationEstimator for error normalization
 using JetBrains.Annotations;
 using Perfolizer.Mathematics.Common;
 using Perfolizer.Mathematics.Distributions.ContinuousDistributions;

--- a/src/Perfolizer/Perfolizer/Mathematics/Common/PairwiseEstimatorHelper.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Common/PairwiseEstimatorHelper.cs
@@ -29,7 +29,7 @@ public static class PairwiseEstimatorHelper
                 for (int j = i + skip; j < n; j++)
                 {
                     values[k] = func(x.Values[i], x.Values[j]);
-                    weights[k++] = x.Weights[i] * x.Weights[j];
+                    weights[k++] = x.Weights![i] * x.Weights![j];
                 }
             return estimator.Quantile(new Sample(values, weights), p);
         }
@@ -67,7 +67,9 @@ public static class PairwiseEstimatorHelper
                 for (int j = 0; j < m; j++)
                 {
                     values[k] = func(x.Values[j], y.Values[i]);
-                    weights[k++] = x.Weights[j] * y.Weights[i];
+                    double wx = x.IsWeighted ? x.Weights![j] : 1.0;
+                    double wy = y.IsWeighted ? y.Weights![i] : 1.0;
+                    weights[k++] = wx * wy;
                 }
             return estimator.Quantile(new Sample(values, weights), p);
         }

--- a/src/Perfolizer/Perfolizer/Mathematics/Multimodality/LowlandModalityDetector.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/Multimodality/LowlandModalityDetector.cs
@@ -63,7 +63,7 @@ public class LowlandModalityDetector : IModalityDetector
                 if (left <= value && value <= right)
                 {
                     modeValues.Add(value);
-                    modeWeights?.Add(sample.SortedWeights[i]);
+                    modeWeights?.Add(sample.SortedWeights![i]);
                 }
             }
             if (modeValues.Count == 0)

--- a/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/HarrellDavisQuantileEstimator.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/HarrellDavisQuantileEstimator.cs
@@ -72,7 +72,7 @@ public class HarrellDavisQuantileEstimator : IQuantileEstimator, IQuantileConfid
         {
             double betaCdfLeft = betaCdfRight;
             currentProbability += sample.IsWeighted
-                ? sample.SortedWeights[j] / sample.TotalWeight
+                ? sample.SortedWeights![j] / sample.TotalWeight
                 : 1.0 / sample.Size;
 
             double cdfValue = distribution.Cdf(currentProbability);

--- a/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/HyndmanFanQuantileEstimator.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/HyndmanFanQuantileEstimator.cs
@@ -75,7 +75,7 @@ public class HyndmanFanQuantileEstimator : IQuantileEstimator
         double current = 0;
         for (int i = 0; i < n; i++)
         {
-            double next = current + sample.SortedWeights[i] / totalWeight;
+            double next = current + sample.SortedWeights![i] / totalWeight;
             result += sample.SortedValues[i] * (Cdf(next) - Cdf(current));
             current = next;
         }

--- a/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/TrimmedHarrellDavisQuantileEstimator.cs
+++ b/src/Perfolizer/Perfolizer/Mathematics/QuantileEstimators/TrimmedHarrellDavisQuantileEstimator.cs
@@ -51,7 +51,7 @@ public class TrimmedHarrellDavisQuantileEstimator : IQuantileEstimator
             for (int j = 0; j < sample.Size; j++)
             {
                 double betaCdfLeft = betaCdfRight;
-                currentProbability += sample.SortedWeights[j] / sample.TotalWeight;
+                currentProbability += sample.SortedWeights![j] / sample.TotalWeight;
 
                 double cdfValue = Cdf(currentProbability);
                 betaCdfRight = cdfValue;

--- a/src/Perfolizer/Perfolizer/Perfonar/Functions/PerfonarFunctionResolver.cs
+++ b/src/Perfolizer/Perfolizer/Perfonar/Functions/PerfonarFunctionResolver.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618 // 'spread' intentionally uses the obsolete bias-corrected Shamos estimator
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Perfolizer.Extensions;


### PR DESCRIPTION
Clear the CS8602 nullable-reference and CS0618 obsolete-usage warnings from the build logs. The nullable ones are false positives under the `IsWeighted` invariant the compiler can't carry across a property/method boundary (marked null-forgiving), except one real latent NRE in the two-sample pairwise helper where a mixed-weighted pair dereferenced the unweighted side's null weights. The intentional obsolete `ScaleEstimator` usages (demo, simulation tests, the Perfonar `spread` function) get the same file-scoped suppression already used across the obsolete surface.

Base of a stacked series.

---
**Stack** (merge bottom → top):
1. #24 fix: compiler warnings
2. #25 ci: bump GitHub Actions
3. #26 chore(deps): minor bumps
4. #27 chore: adopt .NET 10 / C#14
5. #28 chore(deps): xunit v2 → v3
6. #29 ci: full test suite + drop unused ref