### PR TITLE
chore(deps): bump JetBrains.Annotations, System.Memory, and xunit

### DIFF
--- a/src/Perfolizer/Perfolizer.SimulationTests/Perfolizer.SimulationTests.csproj
+++ b/src/Perfolizer/Perfolizer.SimulationTests/Perfolizer.SimulationTests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Perfolizer/Perfolizer.Tests/Perfolizer.Tests.csproj
+++ b/src/Perfolizer/Perfolizer.Tests/Perfolizer.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Perfolizer/Perfolizer/Perfolizer.csproj
+++ b/src/Perfolizer/Perfolizer/Perfolizer.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" PrivateAssets="All" />
     <PackageReference Include="Pragmastat" Version="13.0.1" />
-    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.5.5"/>
+    <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.6.3"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Minor/patch dependency bumps with no API impact: JetBrains.Annotations 2025.2.2 → 2026.2.0, System.Memory 4.5.5 → 4.6.3, xunit 2.9.0 → 2.9.3.

Stacked on `chore/bump-github-actions`.

---
**Stack** (merge bottom → top):
1. #24 fix: compiler warnings
2. #25 ci: bump GitHub Actions
3. #26 chore(deps): minor bumps
4. #27 chore: adopt .NET 10 / C#14
5. #28 chore(deps): xunit v2 → v3
6. #29 ci: full test suite + drop unused ref