### PR TITLE
chore: adopt .NET 10 SDK and C# 14 for tests and tooling

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-dotnet = "9"
+dotnet = "10"
 
 [tasks.build]
 description = "Build the project"

--- a/src/Perfolizer/Directory.Build.props
+++ b/src/Perfolizer/Directory.Build.props
@@ -17,7 +17,7 @@
         <AssemblyOriginatorKeyFile>..\perfolizerKey.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
 
-        <LangVersion>12.0</LangVersion>
+        <LangVersion>14.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Perfolizer/Perfolizer.Demo/Perfolizer.Demo.csproj
+++ b/src/Perfolizer/Perfolizer.Demo/Perfolizer.Demo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Perfolizer/Perfolizer.SimulationTests/Perfolizer.SimulationTests.csproj
+++ b/src/Perfolizer/Perfolizer.SimulationTests/Perfolizer.SimulationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Perfolizer/Perfolizer.Simulations/Perfolizer.Simulations.csproj
+++ b/src/Perfolizer/Perfolizer.Simulations/Perfolizer.Simulations.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Perfolizer/Perfolizer.Tests/Perfolizer.Tests.csproj
+++ b/src/Perfolizer/Perfolizer.Tests/Perfolizer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Move the mise dotnet pin to 10 and retarget the non-library projects (tests, demo, simulations) from the EOL net9.0 to net10.0, raising LangVersion to 14.0. The library keeps targeting netstandard2.0 and net6.0 — net6.0 is still consumed by BenchmarkDotNet and must not be dropped.

Stacked on `chore/bump-dependencies`.

---
**Stack** (merge bottom → top):
1. #24 fix: compiler warnings
2. #25 ci: bump GitHub Actions
3. #26 chore(deps): minor bumps
4. #27 chore: adopt .NET 10 / C#14
5. #28 chore(deps): xunit v2 → v3
6. #29 ci: full test suite + drop unused ref