### PR TITLE
ci: run the full test suite and drop an unused reference

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ run = "dotnet build src/Perfolizer/Perfolizer.sln -c Release"
 
 [tasks.test]
 description = "Run tests"
-run = "dotnet test src/Perfolizer/Perfolizer.Tests -c Release --no-build"
+run = "dotnet test src/Perfolizer/Perfolizer.sln -c Release --no-build"
 
 [tasks.check]
 description = "Run all static analysis"

--- a/src/Perfolizer/Perfolizer.Simulations/Perfolizer.Simulations.csproj
+++ b/src/Perfolizer/Perfolizer.Simulations/Perfolizer.Simulations.csproj
@@ -9,7 +9,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Perfolizer.SimulationTests\Perfolizer.SimulationTests.csproj" />
-        <ProjectReference Include="..\Perfolizer.Tests\Perfolizer.Tests.csproj" />
         <ProjectReference Include="..\Perfolizer\Perfolizer.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
The test task ran only Perfolizer.Tests, so the 2618 SimulationTests were built but never executed in CI — point it at the solution so every test project runs (and future ones are picked up automatically). Also drops an unused Perfolizer.Tests project reference from Simulations.

Stacked on `chore/migrate-xunit-v3`.

---
**Stack** (merge bottom → top):
1. #24 fix: compiler warnings
2. #25 ci: bump GitHub Actions
3. #26 chore(deps): minor bumps
4. #27 chore: adopt .NET 10 / C#14
5. #28 chore(deps): xunit v2 → v3
6. #29 ci: full test suite + drop unused ref