### PR TITLE
feat: Add NewLine option to LightJsonSettings

### DIFF
--- a/src/Perfolizer/Perfolizer/Json/LightJsonSerializer.cs
+++ b/src/Perfolizer/Perfolizer/Json/LightJsonSerializer.cs
@@ -219,7 +219,7 @@ public class LightJsonSerializer
     private void AppendNextLine()
     {
         if (settings.Indent)
-            builder.AppendLine();
+            builder.Append(settings.NewLine);
     }
 
     private void AppendSpace()

--- a/src/Perfolizer/Perfolizer/Json/LightJsonSettings.cs
+++ b/src/Perfolizer/Perfolizer/Json/LightJsonSettings.cs
@@ -3,4 +3,19 @@ namespace Perfolizer.Json;
 public class LightJsonSettings
 {
     public bool Indent { get; set; }
+
+    public string NewLine
+    {
+        get => field ?? Environment.NewLine;
+        set
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            if (value != "\n" && value != "\r\n")
+                throw new ArgumentOutOfRangeException(nameof(value));
+
+            field = value;
+        }
+    }
 }


### PR DESCRIPTION
This PR add `NewLine` option to LightJsonSettings.

It's expected to be used to gets same serialization results between platforms by explicitly specify `NewLine` chars.

Example:
https://github.com/dotnet/BenchmarkDotNet/blob/2365829b82d95843e561f9ef666f4e9e86761d38/tests/BenchmarkDotNet.Tests/Perfonar/PerfonarTests.cs#L25-L28
