### PR TITLE
chore(deps): upgrade Pragmastat from 13.0.1 to 14.0.0

### DIFF
--- a/src/Perfolizer/Perfolizer/Perfolizer.csproj
+++ b/src/Perfolizer/Perfolizer/Perfolizer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" PrivateAssets="All" />
-    <PackageReference Include="Pragmastat" Version="13.0.1" />
+    <PackageReference Include="Pragmastat" Version="14.0.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.6.3"/>
   </ItemGroup>
 


### PR DESCRIPTION
Moves the core statistical engine to Pragmastat 14.0.0. None of the v14 C# breaking changes reach us: we never passed the dropped `Random` argument to `CenterImpl.Estimate`/`SpreadImpl.Estimate`, we do not use `UniformInt64`, and `WeightedSampleNotSupportedException` is our own type rather than the one whose serialization constructor was removed. The build is clean and the full suite passes unchanged, including the estimators affected by v14's exact pairwise-margin arithmetic and by C# `center`/`spread` becoming deterministic.

## Appendix

Verified locally with `-p:PublicSign=true`: build 0 errors / 0 warnings, `Perfolizer.Tests` 1028 passed, `Perfolizer.SimulationTests` 2618 passed, `dotnet format --verify-no-changes` clean. The public-signing override is unrelated to this change: strong-name signing needs an RSA+SHA1 signature, which current Fedora crypto-policies refuse, so a full local build fails on untouched `main` too. A separate branch addresses that.

Release notes: https://github.com/AndreyAkinshin/pragmastat/releases/tag/v14.0.0