### PR TITLE
build: use public signing outside CI

### DIFF
--- a/src/Perfolizer/Directory.Build.props
+++ b/src/Perfolizer/Directory.Build.props
@@ -23,6 +23,17 @@
 
         <Version>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)../../VERSION').Trim())</Version>
     </PropertyGroup>
+
+    <!--
+      Strong-name signing requires an RSA+SHA1 signature, which recent distribution crypto
+      policies (Fedora, RHEL) reject at the OpenSSL level, so a full local build fails.
+      Outside CI, embed the public key without computing the signature: InternalsVisibleTo
+      keeps matching, and .NET Core does not verify strong-name signatures on load anyway.
+      CI keeps producing fully signed assemblies for packaging.
+    -->
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' != 'true'">
+        <PublicSign>true</PublicSign>
+    </PropertyGroup>
     <ItemGroup>
         <None Include="..\..\..\docs\logo\dino.png" Link="Properties\dino.png" Pack="true" PackagePath=""/>
     </ItemGroup>


### PR DESCRIPTION
A full local build currently fails on Fedora and RHEL before compiling anything: strong-name signing needs an RSA+SHA1 signature, and recent distribution crypto policies reject that at the OpenSSL level. Dropping `SignAssembly` is not a way out, since `InternalsVisibleTo` is granted by public key and unsigned test assemblies lose access to internals. This enables `PublicSign` outside CI, so the public key still lands in the manifest and `InternalsVisibleTo` keeps matching while no RSA signature is computed. CI is unaffected and keeps producing fully signed assemblies for packaging.

## Appendix

Reproduces on untouched `main`, with the failure coming from `csc` itself:

```
Microsoft.CSharp.Core.targets(89,5): error : Unhandled exception. Interop+Crypto+OpenSslCryptographicException: error:03000098:digital envelope routines::invalid digest
   at Interop.Crypto.RsaSignHash(...)
   at Microsoft.CodeAnalysis.SigningUtilities.CalculateRsaSignature(...)
```

The policy is stock `DEFAULT`, and the restriction is not specific to .NET:

```
$ openssl dgst -sha1   -sign key.pem msg.txt   ->  blocked
$ openssl dgst -sha256 -sign key.pem msg.txt   ->  ok
```

After this change `mise run ci` passes locally end to end: build 0 errors / 0 warnings, 1028 + 2618 tests passed. Building with `GITHUB_ACTIONS=true` still takes the real-signing path, confirming the CI and packaging behavior is unchanged.