### PR TITLE
fix: restore culture-independent measurement formatting

### DIFF
--- a/src/Perfolizer/Perfolizer.Tests/Helpers/ProcessorBrandStringTests.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Helpers/ProcessorBrandStringTests.cs
@@ -2,6 +2,7 @@
 using Perfolizer.Horology;
 using Perfolizer.Mathematics.Common;
 using Perfolizer.Models;
+using Perfolizer.Tests.Infra;
 
 namespace Perfolizer.Tests.Helpers;
 
@@ -78,4 +79,24 @@ public class ProcessorBrandStringTests
         var cpu = new CpuInfo { ProcessorName = processorName };
         Assert.Equal(brandName, cpu.ToShortBrandName(includeMaxFrequency: true));
     }
+
+    /// <summary>
+    /// A brand string identifies hardware, so it must read the same on every machine.
+    /// There is no way to pass a culture into the brand helpers, hence the invariant default matters here.
+    /// </summary>
+    [Theory]
+    [InlineData("ru-RU")]
+    [InlineData("de-DE")]
+    [InlineData("en-US")]
+    public void BrandNameIsCultureIndependent(string cultureName) =>
+        CultureScope.Run(cultureName, () =>
+        {
+            var cpu = new CpuInfo
+            {
+                ProcessorName = "Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz",
+                NominalFrequencyHz = Frequency.FromGHz(3.1).Hertz.RoundToLong()
+            };
+            Assert.Equal("Intel Core i7-6700HQ CPU 2.60GHz (Max: 3.10GHz) (Skylake)",
+                cpu.ToShortBrandName(includeMaxFrequency: true));
+        });
 }

--- a/src/Perfolizer/Perfolizer.Tests/Infra/CultureScope.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Infra/CultureScope.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+
+namespace Perfolizer.Tests.Infra;
+
+/// <summary>
+/// Runs an assertion under a specific ambient culture and restores the previous one afterwards.
+/// Perfolizer output is expected to be culture-independent, and the test host usually runs under
+/// an invariant-like culture, so such regressions are invisible without an explicit switch.
+/// </summary>
+public static class CultureScope
+{
+    public static void Run(string cultureName, Action action)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+            action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+}

--- a/src/Perfolizer/Perfolizer.Tests/Metrology/MeasurementFormatterTests.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Metrology/MeasurementFormatterTests.cs
@@ -1,15 +1,78 @@
 using System.Globalization;
 using Perfolizer.Horology;
 using Perfolizer.Metrology;
+using Perfolizer.Tests.Infra;
+using Pragmastat.Metrology;
 
 namespace Perfolizer.Tests.Metrology;
 
+/// <summary>
+/// MeasurementFormatter is the codec behind Threshold parsing, sample parsing, and every
+/// "value+unit" string that travels through configs and command lines.
+/// These tests pin down the current wire format: they describe what it is, not what it should be.
+/// </summary>
 public class MeasurementFormatterTests
 {
+    [Theory]
+    // Dimensionless
+    [InlineData("1")]
+    // Time
+    [InlineData("2ns")]
+    [InlineData("3.5us")]
+    [InlineData("4ms")]
+    [InlineData("5s")]
+    [InlineData("6m")]
+    [InlineData("7h")]
+    [InlineData("8d")]
+    // Size
+    [InlineData("9B")]
+    [InlineData("10KB")]
+    [InlineData("11MB")]
+    [InlineData("12GB")]
+    [InlineData("13TB")]
+    // Percent
+    [InlineData("14%")]
+    // Frequency
+    [InlineData("17Hz")]
+    [InlineData("18KHz")]
+    [InlineData("19MHz")]
+    [InlineData("20GHz")]
+    public void RoundTripTest(string s)
+    {
+        var formatter = MeasurementFormatter.Default;
+        Assert.True(formatter.TryParse(s, out var measurement), $"Failed to parse '{s}'");
+        Assert.Equal(s, formatter.Format(measurement));
+    }
+
+    /// <summary>
+    /// The codec writes the value and the abbreviation with no separator, but accepts both forms on input.
+    /// </summary>
+    [Theory]
+    [InlineData("3.5us")]
+    [InlineData("3.5 us")]
+    public void ParseAcceptsOptionalGapTest(string s)
+    {
+        Assert.True(MeasurementFormatter.Default.TryParse(s, out var measurement));
+        Assert.Equal(3.5, measurement.NominalValue);
+        Assert.Equal(TimeUnit.Microsecond, measurement.Unit);
+    }
+
+    /// <summary>
+    /// Ratio and Disparity carry no abbreviation, so they are indistinguishable from plain numbers
+    /// once serialized. Parsing such a string yields a Number measurement.
+    /// </summary>
+    [Theory]
+    [InlineData("16")]
+    public void UnitlessFamiliesCollapseToNumberTest(string s)
+    {
+        Assert.True(MeasurementFormatter.Default.TryParse(s, out var measurement));
+        Assert.Equal(MeasurementUnit.Number, measurement.Unit);
+    }
+
     /// <summary>
     /// Formatting must not depend on the ambient culture: callers that do not pass a format provider
-    /// (e.g. TimeInterval.ToString(), Frequency.ToString(), CpuBrandHelper) always produce '.' as the
-    /// decimal separator, so that reports stay identical across machines.
+    /// (TimeInterval.ToString(), Frequency.ToString(), Threshold.ToString(), CpuBrandHelper) have to
+    /// produce identical output on every machine.
     /// </summary>
     [Theory]
     [InlineData("ru-RU")]
@@ -17,18 +80,23 @@ public class MeasurementFormatterTests
     [InlineData("en-US")]
     public void FormatIsCultureIndependentTest(string cultureName)
     {
-        var previousCulture = CultureInfo.CurrentCulture;
-        try
+        CultureScope.Run(cultureName, () =>
         {
-            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
-
             var measurement = Frequency.FromGHz(3.1).ToMeasurement(FrequencyUnit.GHz);
             Assert.Equal("3.10GHz", MeasurementFormatter.Default.Format(measurement, "N2"));
             Assert.Equal("1.234us", TimeInterval.FromNanoseconds(1234).ToString());
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = previousCulture;
-        }
+            Assert.Equal("1.5KB", SizeValue.FromBytes(1024 + 512).ToString());
+        });
+    }
+
+    /// <summary>
+    /// An explicitly passed provider still wins over the invariant default.
+    /// </summary>
+    [Fact]
+    public void ExplicitFormatProviderIsRespectedTest()
+    {
+        var measurement = Frequency.FromGHz(3.1).ToMeasurement(FrequencyUnit.GHz);
+        string actual = MeasurementFormatter.Default.Format(measurement, "N2", new CultureInfo("ru-RU"));
+        Assert.Equal("3,10GHz", actual);
     }
 }

--- a/src/Perfolizer/Perfolizer.Tests/Metrology/MeasurementFormatterTests.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Metrology/MeasurementFormatterTests.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using Perfolizer.Horology;
+using Perfolizer.Metrology;
+
+namespace Perfolizer.Tests.Metrology;
+
+public class MeasurementFormatterTests
+{
+    /// <summary>
+    /// Formatting must not depend on the ambient culture: callers that do not pass a format provider
+    /// (e.g. TimeInterval.ToString(), Frequency.ToString(), CpuBrandHelper) always produce '.' as the
+    /// decimal separator, so that reports stay identical across machines.
+    /// </summary>
+    [Theory]
+    [InlineData("ru-RU")]
+    [InlineData("de-DE")]
+    [InlineData("en-US")]
+    public void FormatIsCultureIndependentTest(string cultureName)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+
+            var measurement = Frequency.FromGHz(3.1).ToMeasurement(FrequencyUnit.GHz);
+            Assert.Equal("3.10GHz", MeasurementFormatter.Default.Format(measurement, "N2"));
+            Assert.Equal("1.234us", TimeInterval.FromNanoseconds(1234).ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+}

--- a/src/Perfolizer/Perfolizer.Tests/Metrology/ThresholdTests.cs
+++ b/src/Perfolizer/Perfolizer.Tests/Metrology/ThresholdTests.cs
@@ -1,0 +1,35 @@
+using Perfolizer.Metrology;
+using Perfolizer.Tests.Infra;
+
+namespace Perfolizer.Tests.Metrology;
+
+/// <summary>
+/// Threshold strings are round-tripped through configs and command lines, and their presentation
+/// reaches end users: BenchmarkDotNet puts Threshold.ToString() into a column name and a column id.
+/// </summary>
+public class ThresholdTests
+{
+    [Theory]
+    [InlineData("5%")]
+    [InlineData("2.5%")]
+    [InlineData("10ms")]
+    [InlineData("100ns")]
+    [InlineData("1s")]
+    [InlineData("5%|10ms")]
+    public void RoundTripTest(string s)
+    {
+        Assert.True(Threshold.TryParse(s, out var threshold), $"Failed to parse '{s}'");
+        Assert.Equal(s, threshold.ToString());
+    }
+
+    [Theory]
+    [InlineData("ru-RU")]
+    [InlineData("de-DE")]
+    [InlineData("en-US")]
+    public void ToStringIsCultureIndependentTest(string cultureName) =>
+        CultureScope.Run(cultureName, () =>
+        {
+            Assert.True(Threshold.TryParse("2.5%", out var threshold));
+            Assert.Equal("2.5%", threshold.ToString());
+        });
+}

--- a/src/Perfolizer/Perfolizer/Metrology/MeasurementFormatter.cs
+++ b/src/Perfolizer/Perfolizer/Metrology/MeasurementFormatter.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Perfolizer.Common;
 using Pragmastat.Metrology;
 
 namespace Perfolizer.Metrology;
@@ -9,7 +10,7 @@ public class MeasurementFormatter
 
     public string Format(Measurement measurement, string? format = null, IFormatProvider? formatProvider = null)
     {
-        string valueStr = measurement.NominalValue.ToString(format, formatProvider);
+        string valueStr = measurement.NominalValue.ToString(format, formatProvider ?? DefaultCultureInfo.Instance);
         string abbreviation = measurement.Unit.Abbreviation;
         return abbreviation.Length == 0 ? valueStr : valueStr + abbreviation;
     }


### PR DESCRIPTION
The Pragmastat 11 upgrade replaced the inherited `MeasurementFormatter`, whose `Format()` defaulted `formatProvider` to the invariant culture, with a standalone one that passes the caller's null straight to `double.ToString()`. Every call site that cannot supply a provider now follows the ambient culture, so on a ru-RU machine a processor brand renders as `(Max: 3,10GHz)` and a BenchmarkDotNet column name becomes `MannWhitney(2,5%)`. This restores the invariant default and adds the formatting tests that disappeared when `MetrologyTests` was removed alongside the old API.

## Appendix

Paths affected, all of them without a provider to pass: `CpuBrandHelper` (formats the frequency with a hardcoded `"N2"`), `Threshold.ToString()`, `TimeInterval`/`Frequency`/`SizeValue.ToString()`, and histogram bins. Perfonar tables are unaffected because `PerfonarTableView` passes `style.FormatProvider` explicitly, which is also why CI never caught this: the remaining format tests run under an invariant-like ambient culture.

The default is `DefaultCultureInfo.Instance`, matching `ConfidenceInterval`, `ConfidenceLevel`, `Range`, `LightJsonSerializer`, and `PerfonarTableStyle`. Note this differs from the pre-0.7.0 default (`CultureInfo.InvariantCulture`) for `"N"` formats on values above a thousand: `1234.50` instead of `1,234.50`. Worth deciding whether to unify the two invariant constants, since `DoubleExtensions.Format` still falls back to `CultureInfo.InvariantCulture`.

Tests cover the contract without changing it: round-trip `Parse`/`Format` across every unit family (restoring the intent of the deleted test), both input spellings (`3.5us` and `3.5 us`), formatting under ru-RU/de-DE/en-US for the three user-facing paths, and an explicit provider still overriding the default. Six cases fail without the fix. Expected strings encode today's gap-less layout deliberately, so the suite is characterization, not a design statement.

One thing surfaced while writing the round-trip cases: `MeasurementUnit.Ratio` and `.Disparity` now carry an empty abbreviation, so they collapse into `Number` once serialized. `16x` no longer parses. Harmless today, but ratio thresholds are exactly what `Toolkit.Compare2` takes.