### PR TITLE
chore(deps): upgrade Pragmastat from 14.0.0 to 14.0.1

### DIFF
--- a/src/Perfolizer/Perfolizer/Perfolizer.csproj
+++ b/src/Perfolizer/Perfolizer/Perfolizer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" PrivateAssets="All" />
-    <PackageReference Include="Pragmastat" Version="14.0.0" />
+    <PackageReference Include="Pragmastat" Version="14.0.1" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.6.3"/>
   </ItemGroup>
 


### PR DESCRIPTION
Patch upgrade of the Pragmastat dependency. The 14.0.1 release only touches documentation tooling and build pinning, so there are no API or behavioral changes on the .NET side; the full suite passes unchanged.